### PR TITLE
Library for calculating active users by day / platform

### DIFF
--- a/src/lib/reporting.js
+++ b/src/lib/reporting.js
@@ -1,0 +1,48 @@
+exports.dailyActiveUsersGrouped = (db, cb, ts, days) => {
+  ts = ts || (new Date()).getTime()
+  days = days || 7
+
+  var query = db.collection('usage').aggregate([
+    {
+      $match: { daily: true }
+    },
+    {
+      $project: {
+        date: {
+          $add : [ (new Date(0)), '$ts' ]
+        },
+        platform: {
+          $ifNull: [ '$platform', 'unknown' ]
+        },
+        version: {
+          $ifNull: [ '$version', 'unknown' ]
+        },
+        ymd: {
+          $dateToString: {
+            format: "%Y-%m-%d", date: {
+              $add : [ (new Date(-5 * 60 * 60000)), '$ts' ]
+            }
+          }
+        }
+      }
+    },
+    {
+      $group: {
+        _id: { ymd: '$ymd', platform: '$platform' },
+        count: {
+          $sum: 1
+        }
+      }
+    },
+    {
+      $sort: {
+        '_id.ymd': -1,
+        '_id.platform': 1
+      }
+    }
+  ])
+
+  query.toArray((err, result) => {
+    cb(err, result)
+  })
+}

--- a/src/scripts/dau.js
+++ b/src/scripts/dau.js
@@ -1,0 +1,15 @@
+/*
+ * Simple script to return number of active users by day / platform
+ */
+
+var db = require('../db')
+var reporting = require('../lib/reporting')
+var assert = require('assert')
+
+db.setup((mongo) => {
+  reporting.dailyActiveUsersGrouped(mongo, (err, dau) => {
+    assert.equal(err, null)
+    console.log(dau)
+    mongo.close()
+  })
+})


### PR DESCRIPTION
- Library with Mongo aggregate call
- Simple script to demonstrate capability and retrieve results in terminal
