### PR TITLE
Add nsp security check

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Auto-update server for Brave laptop browser",
   "main": "index.js",
   "scripts": {
+    "checks": "npm run check-security",
+    "check-security": "nsp check",
     "start": "node dist/index.js",
     "build": "babel src --out-dir dist --source-maps",
     "preinstall": "babel src --out-dir dist --source-maps",
@@ -29,6 +31,7 @@
     "yargs": "^3.31.0"
   },
   "devDependencies": {
+    "nsp": "^2.2.0",
     "standard": "^5.4.1"
   },
   "precommit": [

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Auto-update server for Brave laptop browser",
   "main": "index.js",
   "scripts": {
-    "checks": "npm run check-security",
-    "check-security": "nsp check",
+    "test": "npm run test-security",
+    "test-security": "nsp check",
     "start": "node dist/index.js",
     "build": "babel src --out-dir dist --source-maps",
     "preinstall": "babel src --out-dir dist --source-maps",

--- a/src/.nsprc
+++ b/src/.nsprc
@@ -1,0 +1,3 @@
+{
+  "exceptions": ["https://nodesecurity.io/advisories/77"]
+}


### PR DESCRIPTION
I think [advisory 77](https://nodesecurity.io/advisories/77) is probably not an issue here since it is introduced in Babel CLI which is being used to transpile only.
