### PR TITLE
Upgrade Windows users that are on a preview build but have not

### DIFF
--- a/src/controllers/releases.js
+++ b/src/controllers/releases.js
@@ -66,14 +66,13 @@ let buildReleaseNotes = (potentials) => {
 
 // This function checks for the following conditions:
 //
-//  * Browser is winx64 or winia32
 //  * The currently installed release is a preview build
 //  * Assumes that accept_preview=false checked already
 //
-var specialWindowsPreviewUpgrade = (releases, version, channel, platform) => {
-  if (platform.match(/^win/)) {
-    var release = releases[channel + ':' + platform].find((rel) => { return rel.version === version })
-    return release && release.preview
+var specialPreviewUpgrade = (releases, version, channel, platform) => {
+  var release = releases[channel + ':' + platform].find((rel) => { return rel.version === version })
+  if (release) {
+    return release.preview
   }
   return false
 }
@@ -87,7 +86,7 @@ var potentialReleases = (releases, channel, platform, version, accept_preview) =
         return semver.gt(rel.version, version)
       } else {
         return (semver.gt(rel.version, version) && !rel.preview) ||
-               (semver.gt(rel.version, version) && specialWindowsPreviewUpgrade(releases, version, channel, platform))
+               (semver.gt(rel.version, version) && specialPreviewUpgrade(releases, version, channel, platform))
       }
     }
   )

--- a/src/controllers/releases.js
+++ b/src/controllers/releases.js
@@ -64,6 +64,20 @@ let buildReleaseNotes = (potentials) => {
   return potentials.map((release) => release.notes).join('\n\n')
 }
 
+// This function checks for the following conditions:
+//
+//  * Browser is winx64 or winia32
+//  * The currently installed release is a preview build
+//  * Assumes that accept_preview=false checked already
+//
+var specialWindowsPreviewUpgrade = (releases, version, channel, platform) => {
+  if (platform.match(/^win/)) {
+    var release = releases[channel + ':' + platform].find((rel) => { return rel.version === version })
+    return release && release.preview
+  }
+  return false
+}
+
 // Build list of releases potentially available for upgrade
 var potentialReleases = (releases, channel, platform, version, accept_preview) => {
   return _.filter(
@@ -72,7 +86,8 @@ var potentialReleases = (releases, channel, platform, version, accept_preview) =
       if (accept_preview === 'true') {
         return semver.gt(rel.version, version)
       } else {
-        return semver.gt(rel.version, version) && !rel.preview
+        return (semver.gt(rel.version, version) && !rel.preview) ||
+               (semver.gt(rel.version, version) && specialWindowsPreviewUpgrade(releases, version, channel, platform))
       }
     }
   )


### PR DESCRIPTION
checked the accept preview option in advanced preferences.

This change will prompt Windows browsers to upgrade to a newer
preview release if they are currently on a preview build and
have not enabled the accept preview option.

Auditors: @bbondy