### PR TITLE
Bump Ad Block extensions to version 1.0.2

### DIFF
--- a/data/stable/extensions/extensionManifest.json
+++ b/data/stable/extensions/extensionManifest.json
@@ -12,232 +12,232 @@
     "Brave Dark Theme"
   ],
   [
-    "cffkpbalmllkdoenhmdmpbkajipdjfam",
-    "1.0.1",
-    "0820e12d9a229a2acce4d14fa98c4637d5f58a90eca0291394639bf51210ec43",
-    "Brave Ad Block Updater"
-  ],
-  [
-    "ghnjmapememheddlfgmklijahiofgkea",
-    "1.0.1",
-    "f2d787e4c4a62a76707ff28c77404eb797ffc6609d922a8cabda6fa2265072b2",
-    "Brave Ad Block Updater (JPN: ABP Japanese filters (日本用フィルタ))"
-  ],
-  [
     "fnpjliiiicbbpkfihnggnmobcpppjhlj",
-    "1.0.1",
-    "a159b78efbf1388ba3cc3790e3ac8953dc702794ca3388eb354efbc080805e06",
+    "1.0.2",
+    "d2713a42597e90fec8b1c7731d31ade59369dcf82de715d3c49fd183b16ca256",
     "Brave Ad Block Updater (EST: Eesti saitidele kohandatud filter)"
   ],
   [
-    "dmoefgliihlcfplldbllllbofegmojne",
-    "1.0.1",
-    "454f2ce723594cd0d579fa09cb923236b8482f0a426d5a65496f72accf996bb4",
-    "Brave Ad Block Updater (RUS: Adguard Russian Filter)"
-  ],
-  [
-    "llhecljkijgcaalnbfadljdpkpbehakp",
-    "1.0.1",
-    "6d94625e247f2b3024cb3fa197211ab59356fdaaa221ed14f6977c17fc1788fe",
-    "Brave Ad Block Updater (CHN: EasyList China (中文))"
-  ],
-  [
     "hmabmnondepbfogenlfklniehjedmicd",
-    "1.0.1",
-    "5774731d26026c49b72f3939a9ef852b2c5cd247fbcbeffb7d4d90cea5e264e0",
+    "1.0.2",
+    "0767303d1e33af7fc9d2ff67592223535e0910c19b88c538ec2508f665f65d63",
     "Brave Ad Block Updater (LVA: Latvian List)"
   ],
   [
-    "oooemoeokehlgldpjjhcgbndjcekllim",
-    "1.0.1",
-    "9cfec4193ed84a0aee1cbf031ee609449f97792780a865bd07744795e27c24db",
-    "Brave Ad Block Updater (TUR: Adguard Turkish Filter)"
-  ],
-  [
     "kdcalgmhljnckmnfcboeabeepgnlaemf",
-    "1.0.1",
-    "c21e9551a9e070e6be4fc47e4ad3807d3494799bf711ca575a769745725f0c88",
+    "1.0.2",
+    "87e2b7c356d1cfdb8b8c99334f4fa9c256c12633bfea1c22459211c97d5f3cad",
     "Brave Ad Block Updater (FIN: Finnish Addition to Easylist)"
   ],
   [
-    "jboldinnegecjonfmaahihagfahjceoj",
-    "1.0.1",
-    "efb05a2f4f8f9c5f336bded3f4db033eebb00e5bedb48d87b94e95499c90d082",
-    "Brave Ad Block Updater (KOR: Korean Adblock List)"
-  ],
-  [
     "lddghfaofadfpaajgncgkbjhalgohfkd",
-    "1.0.1",
-    "fe99c16892985ee001bcf7d3de1e6359782a8a70eb8bb3b4d188f6908c051688",
+    "1.0.2",
+    "d10ddfc6980a8b21b7fb6c3840663468203d9a051ea45c721c174970c7fbac76",
     "Brave Ad Block Updater (SVN: Slovenian List)"
   ],
   [
-    "djhjpnilfflibdflbkgapjfldapkjcgl",
-    "1.0.1",
-    "15432ac88535387562b8134b6908c39c34af75f29a7a4b3909c9d20950bb9c2a",
-    "Brave Ad Block Updater (KOR: YousList)"
-  ],
-  [
     "njhlaafgablgnekjaodhgbaomabjibaf",
-    "1.0.1",
-    "abb6c773ebcf8fefaf081b605d7f8c3432bdd4fea3bfbdfc5ce974a54730a79e",
+    "1.0.2",
+    "619147ca921e28237b44b65440e299f820267bbbc68f6d235ef60af3a0beb999",
     "Brave Ad Block Updater (ISL: Icelandic ABP List)"
   ],
   [
     "fijddbnggnpidebfbejillgbopcikfpi",
-    "1.0.1",
-    "77cee0614507ea3e348baaa07e147dc4b2942fb33a63ef95cb7d1595739847d0",
+    "1.0.2",
+    "1d0e36d8d9c1ed41531a4c318e235e7928f8c6ee55fd3b3da66ad46a7a2d9d33",
     "Brave Ad Block Updater (IN: Fanboy's India Filters)"
   ],
   [
-    "ekodlgldheejnlkhiceghfgdcplpeoek",
-    "1.0.1",
-    "b01812b540c28b334b44b9664997a7f23aa3a55710979f43b049187fe0417598",
-    "Brave Ad Block Updater (LTU: Adblock Plus Lithuania)"
-  ],
-  [
-    "oidcknjcjepjgfpammgdalpnjefekhge",
-    "1.0.1",
-    "dcdfc47fe4a53b522ca4980b7c66d8ab9912708daef0b521df3012a68f50c0c4",
-    "Brave Ad Block Updater (KOR: Fanboy's Korean)"
-  ],
-  [
     "abeicfkepbhgindohkebelkkhnnijcaf",
-    "1.0.1",
-    "038776ffea4e586e9f9b4f118076133d20030cf7f0a41b1110e5017e14b7a839",
+    "1.0.2",
+    "9f4b476b3fd58480a54576ce1186358e035168a7ee6ceb078e949e41dd3a7bf0",
     "Brave Ad Block Updater (EU: Prebake - Filter Obtrusive Cookie Notices)"
   ],
   [
     "cklgijeopkpaadeipkhdaodemoenlene",
-    "1.0.1",
-    "4bcffe9b663271c3be9f8f033250896b6b8134871772c9a5ff2a9c1634ace71d",
+    "1.0.2",
+    "141f1e6e78540c0763d57cc3801304d86930d959c96f007910fa2076735d97b0",
     "Brave Ad Block Updater (VIE: Fanboy's Vietnamese)"
   ],
   [
     "pmgkiiodjlmmpimpmphjhkodjnjfkeke",
-    "1.0.1",
-    "c7a333611b5be1f26f71079f1280756795793921e84544547caa1073891570a6",
+    "1.0.2",
+    "977925ab1e6d5a6c2576a99649b1ce306caec0009550dbf45d7109a5c951b1fc",
     "Brave Ad Block Updater (GRC: Greek AdBlock Filter)"
   ],
   [
-    "omkkefoeihpbpebhhbhmjekpnegokpbj",
-    "1.0.1",
-    "5877bb7ca417ae78c30427e0d0fe96ebafa68dfafadb772d974a4b4155fa8ce0",
-    "Brave Ad Block Updater (CZE, SVK: EasyList Czech and Slovak)"
-  ],
-  [
-    "oimfmeehpinnecjghphifehbbnddjkmf",
-    "1.0.1",
-    "7b125c09a45d09270d06c11a967eb786f99711279c228ca8ac3f3e2852568004",
-    "Brave Ad Block Updater (SWE: Frellwit's Filter List)"
-  ],
-  [
-    "enkheaiicpeffbfgjiklngbpkilnbkoi",
-    "1.0.1",
-    "dddc12b1c7ca9ab9075becf1e42d215c18c738413a367f6659a4ece53d0d34e0",
-    "Brave Ad Block Updater (RUS: RU AdList (Дополнительная региональная подписка))"
-  ],
-  [
-    "hjeidaaocognlgpdkfeenmiefipcffbo",
-    "1.0.1",
-    "b3084e8bd908d1b146ce51cfb15b9e6f386c0910f79954b012b009d2013b6137",
-    "Brave Ad Block Updater (ISR: EasyList Hebrew)"
-  ],
-  [
     "lgfeompbgommiobcenmodekodmdajcal",
-    "1.0.1",
-    "0058e2661bdfb1c8b1257f643f924a99f73c1d259260e56eb96034608818e883",
+    "1.0.2",
+    "d2dde0436ba4985137d82c4c9a0bc992f9852fdc6b5b3221b676f4eeba904149",
     "Brave Ad Block Updater (CHN: CJX's EasyList Lite (main focus on Chinese sites))"
   ],
   [
-    "egooomckhdgnfbpofhkbhbkiejaihdll",
-    "1.0.1",
-    "6e058804b6553465a17ee84fe2c6a03153473e46a1a9384739c0d18a8e194682",
-    "Brave Ad Block Updater (IDN: ABPindo)"
-  ],
-  [
-    "emaecjinaegfkoklcdafkiocjhoeilao",
-    "1.0.1",
-    "2709d1bee39fae701f0bb67b3b3b0fbc4065ca77f66c55ca729cc4a460daf74e",
-    "Brave Ad Block Updater (FRA: EasyList Liste FR)"
-  ],
-  [
-    "fbmjnabmpmfnfknjmbegjmjigmelggmf",
-    "1.0.1",
-    "c0a585c705e2d17954fd413b8d3abb277672dcfe5db5203a2d57d4f7bb1d60b3",
-    "Brave Ad Block Updater (NLD: EasyList Dutch)"
-  ],
-  [
     "facajiciiepdpjnoifonbfgcnlbpbieo",
-    "1.0.1",
-    "9b4faad8fc79494286951e083094e6b8b6e2c551b29caac9e51926c4652edd56",
+    "1.0.2",
+    "66c58029953f9cd8b86403403bd9c97822973e52cc831a21b64a9d258527065e",
     "Brave Ad Block Updater (DNK: Schacks Adblock Plus liste)"
   ],
   [
-    "gpgegghiabhggiplapgdfnfcmodkccji",
-    "1.0.1",
-    "9e088cb35985f25f6e7e645a86c2c13101d4cd15cbc6dd8443384abba20ca50e",
-    "Brave Ad Block Updater (ARA: Liste AR)"
-  ],
-  [
-    "agfanagdjcijocanbeednbhclejcjlfo",
-    "1.0.1",
-    "b0bb741d0164ebb433df864a481b2cf7ca5c2d665730be0d8e943bb662c2be0b",
-    "Brave Ad Block Updater (ITA: ABP X Files)"
-  ],
-  [
-    "nkmllpnhpfieajahfpfmjneipnddhimi",
-    "1.0.1",
-    "80e8ca373f5ad5c9d0c4f5563e0dd3ba4db4cac9f0607e856042c2e4b7fe909d",
-    "Brave Ad Block Updater (ITA: EasyList Italy)"
-  ],
-  [
-    "pdecoifadfkklajdlmndjpkhabpklldh",
-    "1.0.1",
-    "7e58eb27077f4c496d1a611fad654d39bca2d3c574c4cae56c14f49097848918",
-    "Brave Ad Block Updater (SPA: EasyList Spanish)"
-  ],
-  [
-    "paoecjnjjbclkgbempaeemcbeldldlbo",
-    "1.0.1",
-    "cfd0969b51d7f12de0c3af8f924907f59039d938ce583aaa225342a1e8902b6a",
-    "Brave Ad Block Updater (POL: polskie filtry do Adblocka i uBlocka)"
-  ],
-  [
     "dbcccdegkijbppmeaihneimbghfghkdl",
-    "1.0.1",
-    "3060e20d3708d119d2038a2ff60c4f42e5178d5b451b8095d4e1f6fad97d0e57",
+    "1.0.2",
+    "559ec7c94b3674500775e733fd6b5d85207ad3a968d06b15b4cf791578defa95",
     "Brave Ad Block Updater (IRN: AdBlock Iran Filter)"
   ],
   [
+    "gemncmbgjgcjjepjkindgdhdilnaanlc",
+    "1.0.2",
+    "91ecaa8eca7615b9e15f5015a499ec7ed4ffdfed4d2b647dab672b1beb8c8dd5",
+    "Brave Ad Block Updater (HUN: hufilter)"
+  ],
+  [
+    "oidcknjcjepjgfpammgdalpnjefekhge",
+    "1.0.2",
+    "ee2ba4884f4d11ee30ee8f1082ef2fee4269d0f5a0d16e2be5f9625680bb9abe",
+    "Brave Ad Block Updater (KOR: Fanboy's Korean)"
+  ],
+  [
+    "ekodlgldheejnlkhiceghfgdcplpeoek",
+    "1.0.2",
+    "bb40bf6fffa7935dd79d758d0768eae73f9c106cd074c652cee6944184880490",
+    "Brave Ad Block Updater (LTU: Adblock Plus Lithuania)"
+  ],
+  [
+    "omkkefoeihpbpebhhbhmjekpnegokpbj",
+    "1.0.2",
+    "c47a19500680ca4974192017f4d994c8f3668aeca20a23546a872f68e062bbeb",
+    "Brave Ad Block Updater (CZE, SVK: EasyList Czech and Slovak)"
+  ],
+  [
+    "hjeidaaocognlgpdkfeenmiefipcffbo",
+    "1.0.2",
+    "fe1985066c47b6f23ea806e6417fbdc5b9884d68e57acccd57b066805dcca3b5",
+    "Brave Ad Block Updater (ISR: EasyList Hebrew)"
+  ],
+  [
+    "oimfmeehpinnecjghphifehbbnddjkmf",
+    "1.0.2",
+    "f1475f61460694bd452b1de796a3f69b2ea3b8752021a9ca60975cc3068c9ae8",
+    "Brave Ad Block Updater (SWE: Frellwit's Filter List)"
+  ],
+  [
+    "fbmjnabmpmfnfknjmbegjmjigmelggmf",
+    "1.0.2",
+    "69c611df0bdb55eae853d9d672482ed0edc90919f92bc27e2d8312c8706bf271",
+    "Brave Ad Block Updater (NLD: EasyList Dutch)"
+  ],
+  [
+    "pdecoifadfkklajdlmndjpkhabpklldh",
+    "1.0.2",
+    "17f070cc8267d26a7a86a2b03a3c915b8120c0bb066995de599b446fe5f753fd",
+    "Brave Ad Block Updater (SPA: EasyList Spanish)"
+  ],
+  [
     "llpoppgpcimnmhgehpipdmamalmpfbjd",
-    "1.0.1",
-    "41c4f79c5ee4525209a75edacd2a51ac9576e47a4ec95abdaab54995d5b4021f",
+    "1.0.2",
+    "1bbd5e54a2a66e7714e1e2e32e58798a5bbd760bdad9db7223b9a3b8618461f7",
     "Brave Ad Block Updater (CHN: CJX's Annoyance List)"
   ],
   [
+    "oooemoeokehlgldpjjhcgbndjcekllim",
+    "1.0.2",
+    "f925a03243cd283072d98215d418c052ba31a686a7359df88c3127603d4e37dc",
+    "Brave Ad Block Updater (TUR: Adguard Turkish Filter)"
+  ],
+  [
+    "djhjpnilfflibdflbkgapjfldapkjcgl",
+    "1.0.2",
+    "25727aa3c71fb9dff51f1afa4f8976c48fbabbac68b79846d2f7a61765032750",
+    "Brave Ad Block Updater (KOR: YousList)"
+  ],
+  [
+    "gpgegghiabhggiplapgdfnfcmodkccji",
+    "1.0.2",
+    "290dc996d2511aeb61b73462e0b34eac65fde61a781089565167c6546f727866",
+    "Brave Ad Block Updater (ARA: Liste AR)"
+  ],
+  [
+    "jboldinnegecjonfmaahihagfahjceoj",
+    "1.0.2",
+    "ce3ee83c0cabc59ca685f86d6bee792a7fe7c1515179f79fa9550663d61e98d2",
+    "Brave Ad Block Updater (KOR: Korean Adblock List)"
+  ],
+  [
+    "agfanagdjcijocanbeednbhclejcjlfo",
+    "1.0.2",
+    "015de75b99d6bff6eb2ba9125d85565549a9492f9d7ee00428e7ef2047a417ad",
+    "Brave Ad Block Updater (ITA: ABP X Files)"
+  ],
+  [
+    "paoecjnjjbclkgbempaeemcbeldldlbo",
+    "1.0.2",
+    "be91552e6f644ba2bd213aa3bbe387038f98458b6f5d80ca0f52b56d483fec4d",
+    "Brave Ad Block Updater (POL: polskie filtry do Adblocka i uBlocka)"
+  ],
+  [
+    "coofeapfgmpkchclgdphgpmfhmnplbpn",
+    "1.0.2",
+    "64f70af530fc2f8b33a46d8d89806ba9054ae11a9fab83cf446a5edf5abb20f2",
+    "Brave Ad Block Updater (BGR: Bulgarian Adblock list)"
+  ],
+  [
+    "nkmllpnhpfieajahfpfmjneipnddhimi",
+    "1.0.2",
+    "96bfdb1c863f0ff4c35c92d44e50a25fc2a16c28527bbaeb2020162d5259a705",
+    "Brave Ad Block Updater (ITA: EasyList Italy)"
+  ],
+  [
     "fmcofgdkijoanfaodpdfjipdgnjbiolk",
-    "1.0.1",
-    "4f1326bbcd0d6770df94871756074bf2637cf450da4e615fe4fe261f8f45d657",
+    "1.0.2",
+    "bc76555e027d64670284eb8cbf0402c1f2114288ce7ee6c557bec5924c337b18",
     "Brave Ad Block Updater (RUS: BitBlock List (Дополнительная подписка фильтров))"
   ],
   [
     "jmomcjcilfpbaaklkifaijjcnancamde",
-    "1.0.1",
-    "d91fa87672d618fc9318ef9c1a82c174959b6e23e3ff06e0021b8b225c383701",
+    "1.0.2",
+    "71599ed7af0fd2e5467b1cdf7017340e79952d8272d94d0f2fb0395f26aeb863",
     "Brave Ad Block Updater (DEU: EasyList Germany)"
   ],
   [
-    "gemncmbgjgcjjepjkindgdhdilnaanlc",
-    "1.0.1",
-    "49cb8905690793c5f3357f614ce80e12c225e5dc3ef0cec050b7fa0548116997",
-    "Brave Ad Block Updater (HUN: hufilter)"
+    "ghnjmapememheddlfgmklijahiofgkea",
+    "1.0.2",
+    "9532e6cb176e294944869fcecad27085893e49101414aab0f81b26f3aea32e8e",
+    "Brave Ad Block Updater (JPN: ABP Japanese filters (日本用フィルタ))"
   ],
   [
-    "coofeapfgmpkchclgdphgpmfhmnplbpn",
-    "1.0.1",
-    "992a7a2147cc1593c638de7c1e80903a0f77e24088ee105f8c841b325b957519",
-    "Brave Ad Block Updater (BGR: Bulgarian Adblock list)"
+    "egooomckhdgnfbpofhkbhbkiejaihdll",
+    "1.0.2",
+    "7f9ffe042625144dc5c411369066498774816ccfaac2d25741ae25b15c9be0e2",
+    "Brave Ad Block Updater (IDN: ABPindo)"
+  ],
+  [
+    "llhecljkijgcaalnbfadljdpkpbehakp",
+    "1.0.2",
+    "22c8c56383822c646828582f32eac4d408bdd5161ec703fa98542ac5458486c2",
+    "Brave Ad Block Updater (CHN: EasyList China (中文))"
+  ],
+  [
+    "dmoefgliihlcfplldbllllbofegmojne",
+    "1.0.2",
+    "db25ef3cf9b93f62c6b8084163319972f80d88982f18a4058d6165082b99cd8b",
+    "Brave Ad Block Updater (RUS: Adguard Russian Filter)"
+  ],
+  [
+    "emaecjinaegfkoklcdafkiocjhoeilao",
+    "1.0.2",
+    "73c29422100064722266fc9955b948464f53b9c063a4e34411ef91de8ae35919",
+    "Brave Ad Block Updater (FRA: EasyList Liste FR)"
+  ],
+  [
+    "enkheaiicpeffbfgjiklngbpkilnbkoi",
+    "1.0.2",
+    "3dbc5462a0c6ed3052e5b4106f3b35f5a00f1df602c216cc4569ce495bebd90b",
+    "Brave Ad Block Updater (RUS: RU AdList (Дополнительная региональная подписка))"
+  ],
+  [
+    "cffkpbalmllkdoenhmdmpbkajipdjfam",
+    "1.0.2",
+    "7a8dda2ab9f3e73274fbcdc2c21a094531d89e0569e4160bc8cd2b09ed78a745",
+    "Brave Ad Block Updater (Default)"
   ],
   [
     "oofiananboodjbbmdelgdommihjbkfag",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3400,13 +3400,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3414,6 +3407,13 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -7870,11 +7870,6 @@
       "integrity": "sha1-76/unx4i01ke1949yqlcP1559zw=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -7890,6 +7885,11 @@
       "resolved": "https://registry.npmjs.org/string.prototype.endswith/-/string.prototype.endswith-0.2.0.tgz",
       "integrity": "sha1-oZwg3uUamHd+mkfhDwm+OTubunU=",
       "dev": true
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringmap": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "./node_modules/.bin/babel-node src/index.js",
     "lint": "standard",
     "verify": "node tools/verify.js",
-    "test": "BEHIND_FASTLY=1 tap test/*.js"
+    "test": "BEHIND_FASTLY=1 tap test/*.js",
+    "test-win": "set BEHIND_FASTLY=1 && tap test/*.js"
   },
   "author": "Brave",
   "license": "MPL-2.0",

--- a/test/extensions.js
+++ b/test/extensions.js
@@ -5,6 +5,7 @@
 var tap = require('tap')
 
 var {getRequestedExtensions, getExtensionsWithUpdates} = require('../src/controllers/extensions')
+var {readExtensions} = require('../src/setup.js')
 
 const request = (appId) => (version) => `
 <?xml version="1.0" encoding="UTF-8"?>
@@ -107,3 +108,7 @@ tap.test('Update for multiple extensions works', (test) => {
   test.end()
 })
 
+tap.test('Extensions manifest is valid', (test) => {
+  tap.ok(readExtensions())
+  test.end()
+})


### PR DESCRIPTION
Incorporates fix for brave/brave-browser#760. Includes test to verify
that extensionManifest.json is well-formed.