### PR TITLE
Mobile redirection endpoint

### DIFF
--- a/src/controllers/promo.js
+++ b/src/controllers/promo.js
@@ -300,7 +300,6 @@ exports.setup = (runtime, releases) => {
           common.userAgentFrom(request),
           request.params.referral_code
         )
-        console.log(redirectURL)
         reply().redirect(redirectURL)
       },
       validate: {

--- a/src/controllers/promo.js
+++ b/src/controllers/promo.js
@@ -13,6 +13,7 @@ const semver = require('semver')
 const uap = require('user-agent-parser')
 
 const common = require('../common')
+const promo = require('../lib/promo')
 
 const S3_DOWNLOAD_BUCKET = process.env.S3_DOWNLOAD_BUCKET || 'brave-download-staging'
 const S3_DOWNLOAD_REGION = process.env.S3_DOWNLOAD_REGION || 'us-east-1'
@@ -288,12 +289,34 @@ exports.setup = (runtime, releases) => {
     }
   }
 
+  const redirectMobileGET = {
+    method: 'GET',
+    path: '/mobile/{referral_code}',
+    config: {
+      tags: ['api'],
+      description: "Redirect to platform specific download handler - noop on desktop",
+      handler: async function (request, reply) {
+        const redirectURL = promo.redirectURLForMobileGet(
+          common.userAgentFrom(request),
+          request.params.referral_code
+        )
+        console.log(redirectURL)
+        reply().redirect(redirectURL)
+      },
+      validate: {
+        params: {
+          referral_code: Joi.string().required()
+        }
+      }
+    }
+  }
   return proxyRoutes.concat([
     android_download_get,
     redirect_download,
     ios_download_get,
     redirect_get,
     ios_initialize_put,
-    nonua_initialize_put
+    nonua_initialize_put,
+    redirectMobileGET
   ])
 }

--- a/src/lib/promo.js
+++ b/src/lib/promo.js
@@ -1,0 +1,18 @@
+const uap = require('user-agent-parser')
+
+const redirectURLForMobileGet = (ua, referralCode) => {
+  // parse the useragent string
+  ua = uap(ua)
+  // match for mobile
+  if (ua.os.name.match(/iOS/)) {
+    return `/download/ios/${referralCode}`
+  }
+  if (ua.os.name.match(/Android/)) {
+    return `/download/android/${referralCode}`
+  }
+  return process.env.MOBILE_DESKTOP_REDIRECT_URL || 'https://www.brave.com'
+}
+
+module.exports = {
+  redirectURLForMobileGet
+}

--- a/test/promo.js
+++ b/test/promo.js
@@ -1,0 +1,13 @@
+const tap = require('tap')
+
+const promo = require('../src/lib/promo')
+
+tap.test('mobile redirect', (t) => {
+  let url = promo.redirectURLForMobileGet('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.54 Safari/537.36', 'ABC123')
+  t.equal(url, 'https://www.brave.com', 'correct default redirect')
+  url = promo.redirectURLForMobileGet('Mozilla/5.0 (iPad; CPU OS 9_3_2 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13F69 Safari/601.1', 'ABC123')
+  t.equal(url, '/download/ios/ABC123', 'correct iOS redirect')
+  url = promo.redirectURLForMobileGet('Mozilla/5.0 (Linux; <Android Version>; <Build Tag etc.>) AppleWebKit/<WebKit Rev> (KHTML, like Gecko) Chrome/<Chrome Rev> Mobile Safari/<WebKit Rev>', 'ABC123')
+  t.equal(url, '/download/android/ABC123', 'correct android redirect')
+  t.end()
+})


### PR DESCRIPTION
* Add an endpoint to redirect as normal for the referral promo for
mobile devices. For desktop, redirect to a statically configured url.
* Add tests