### PR TITLE
Custom headers memory cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "./node_modules/.bin/babel-node src/index.js",
     "lint": "standard",
     "verify": "node tools/verify.js",
-    "test": "BEHIND_FASTLY=1 tap test/*.js",
+    "test": "S3_DOWNLOAD_KEY=1 S3_DOWNLOAD_SECRET=1 BEHIND_FASTLY=1 tap test/*.js",
     "test-win": "set BEHIND_FASTLY=1 && tap test/*.js"
   },
   "author": "Brave",
@@ -47,6 +47,7 @@
     "yargs": "^3.31.0"
   },
   "devDependencies": {
+    "nock": "^11.7.0",
     "s3": "^4.4.0",
     "standard": "^5.4.1",
     "tap": "^6.1.1"

--- a/src/controllers/promo.js
+++ b/src/controllers/promo.js
@@ -58,6 +58,21 @@ const referralDetails = async (referralCode) => {
   return results
 }
 
+const customHeadersCacheFunc = MC.create(parseInt(process.env.CUSTOM_HEADERS_CACHE_TIMEOUT || 30), async () => {
+  const requestOptions = {
+    method: 'GET',
+    uri: `${SERVICES_PROTOCOL}://${SERVICES_HOST}:${SERVICES_PORT}/api/1/promo/custom-headers`,
+    json: true,
+    headers: {
+      Authorization: 'Bearer ' + process.env.AUTH_TOKEN
+    }
+  }
+  if (process.env.FIXIE_URL) {
+    requestOptions.proxy = process.env.FIXIE_URL
+  }
+  return await common.prequest(requestOptions)
+})
+
 exports.setup = (runtime, releases) => {
 
   const previewFilter = process.env.TESTING ?
@@ -69,20 +84,6 @@ exports.setup = (runtime, releases) => {
     .sort((a, b) => { semver.compare(a.version, b.version) })[0].version
   console.log("Serving promo download for version: " + latestVersionNumber)
 
-  const customHeadersCacheFunc = MC.create(parseInt(process.env.CUSTOM_HEADERS_CACHE_TIMEOUT || 30), async () => {
-    const requestOptions = {
-      method: 'GET',
-      uri: `${SERVICES_PROTOCOL}://${SERVICES_HOST}:${SERVICES_PORT}/api/1/promo/custom-headers`,
-      json: true,
-      headers: {
-        Authorization: 'Bearer ' + process.env.AUTH_TOKEN
-      }
-    }
-    if (process.env.FIXIE_URL) {
-      requestOptions.proxy = process.env.FIXIE_URL
-    }
-    return await common.prequest(requestOptions)
-  })
 
   // method, local uri, remote uri, description
   const proxyForwards = [
@@ -490,3 +491,5 @@ exports.setup = (runtime, releases) => {
     customHeadersGet
   ])
 }
+
+exports.customHeadersCacheFunc = customHeadersCacheFunc

--- a/src/controllers/promo.js
+++ b/src/controllers/promo.js
@@ -14,6 +14,7 @@ const uap = require('user-agent-parser')
 
 const common = require('../common')
 const promo = require('../lib/promo')
+const MC = require('../memory-cache')
 
 const S3_DOWNLOAD_BUCKET = process.env.S3_DOWNLOAD_BUCKET || 'brave-browser-downloads'
 const S3_DOWNLOAD_REGION = process.env.S3_DOWNLOAD_REGION || 'us-east-1'
@@ -68,12 +69,38 @@ exports.setup = (runtime, releases) => {
     .sort((a, b) => { semver.compare(a.version, b.version) })[0].version
   console.log("Serving promo download for version: " + latestVersionNumber)
 
+  const customHeadersCacheFunc = MC.create(parseInt(process.env.CUSTOM_HEADERS_CACHE_TIMEOUT || 30), async () => {
+    const requestOptions = {
+      method: 'GET',
+      uri: `${SERVICES_PROTOCOL}://${SERVICES_HOST}:${SERVICES_PORT}/api/1/promo/custom-headers`,
+      json: true,
+      headers: {
+        Authorization: 'Bearer ' + process.env.AUTH_TOKEN
+      }
+    }
+    if (process.env.FIXIE_URL) {
+      requestOptions.proxy = process.env.FIXIE_URL
+    }
+    return await common.prequest(requestOptions)
+  })
+
   // method, local uri, remote uri, description
   const proxyForwards = [
     ['PUT', '/promo/activity', '/api/1/promo/activity', 'Called on periodic check-in and finalization from browser'],
-    ['GET', '/promo/custom-headers', '/api/1/promo/custom-headers', 'Array of custom headers for publishers'],
     ['GET', '/promo/publisher/{referral_code}', '/api/1/promo/publishers/{referral_code}', 'Retrieve details about publisher referral']
   ]
+
+  const customHeadersGet = {
+    method: 'GET',
+    path: '/promo/custom-headers',
+    config: {
+      description: "Retrieve custom headers from referral",
+      tags: ['api'],
+      handler: async (request, reply) => {
+        reply(await customHeadersCacheFunc())
+      }
+    }
+  }
 
   const proxyRoutes = proxyForwards.map((definition) => {
     let route = {
@@ -459,6 +486,7 @@ exports.setup = (runtime, releases) => {
     ios_initialize_put,
     nonua_initialize_put,
     redirectMobileGET,
-    redirect_channel_download
+    redirect_channel_download,
+    customHeadersGet
   ])
 }

--- a/src/memory-cache.js
+++ b/src/memory-cache.js
@@ -1,0 +1,24 @@
+const cache = {}
+
+/*
+ * Create a function A that will store the result of the execution
+ * of an async function B in memory and return the result. Each
+ * subsequent call to function A will return the cached result
+ * if N seconds have not elapsed, or it will again call async
+ * function B, update the memory cache and return the result.
+ */
+const create = (seconds, func) => {
+  let nextRun, v
+  return async () => {
+    if (!nextRun || (new Date()).getTime() > nextRun) {
+      if (process.env.DEBUG) console.log('refilling cache')
+      v = await func()
+      nextRun = (new Date()).getTime() + (seconds * 1000)
+    }
+    return v
+  }
+}
+
+module.exports = {
+  create
+}

--- a/src/memory-cache.js
+++ b/src/memory-cache.js
@@ -8,13 +8,20 @@ const cache = {}
  * function B, update the memory cache and return the result.
  */
 const create = (seconds, func) => {
+  // define variables to hold timestamp of next cache update and
+  // the value to be cached
   let nextRun, v
+  // return function
   return async () => {
+    // if the cache has not been initialized or is due for a refresh
     if (!nextRun || (new Date()).getTime() > nextRun) {
       if (process.env.DEBUG) console.log('refilling cache')
+      // re-fill the cache
       v = await func()
+      // schedule timestamp for next update
       nextRun = (new Date()).getTime() + (seconds * 1000)
     }
+    // return cached value
     return v
   }
 }

--- a/test/custom-header-integration.js
+++ b/test/custom-header-integration.js
@@ -1,0 +1,25 @@
+const tap = require('tap')
+const nock = require('nock')
+const promo = require('../src/controllers/promo')
+
+const SERVICES_HOST = process.env.SERVICES_HOST || 'localhost'
+const SERVICES_PORT = process.env.SERVICES_PORT || 8194
+const SERVICES_PROTOCOL = process.env.SERVICES_PROTOCOL || 'http'
+
+tap.test('custom-headers integration', async (t) => {
+  nock(`${SERVICES_PROTOCOL}://${SERVICES_HOST}:${SERVICES_PORT}`)
+    .get('/api/1/promo/custom-headers')
+    .reply(200, [{"domains":["foo.com"],"headers":{"X-Brave-Partner":"foo"},"cookieNames":[],"expiration":31536000000} ])
+
+  results = await promo.customHeadersCacheFunc()
+  t.equals(results[0].domains[0], 'foo.com', 'domain returned')
+
+  nock(`${SERVICES_PROTOCOL}://${SERVICES_HOST}:${SERVICES_PORT}`)
+    .get('/api/1/promo/custom-headers')
+    .reply(200, [{"domains":["bar.com"],"headers":{"X-Brave-Partner":"bar"},"cookieNames":[],"expiration":31536000000} ])
+
+  results = await promo.customHeadersCacheFunc()
+  t.equals(results[0].domains[0], 'foo.com', 'same domain returned')
+
+  t.end()
+})

--- a/test/memory-cache.js
+++ b/test/memory-cache.js
@@ -1,0 +1,17 @@
+const MC = require('../src/memory-cache')
+const tap = require('tap')
+const uuid = require('uuid/v4')
+
+const snooze = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+tap.test('memory cache', async (t) => {
+  const cacheFunc = MC.create(1, async () => { return uuid() })
+  let value1 = await cacheFunc()
+  t.ok(value1, 'value returned on first call')
+  let value2 = await cacheFunc()
+  t.equal(value1, value2, 'same value returned on second call')
+  await snooze(1500)
+  value2 = await cacheFunc()
+  t.notequal(value1, value2, 'different value returned on third call')
+  t.end()
+})


### PR DESCRIPTION
Add a memory cache for custom-header requests. This will reduce the vast number of calls proxied to the referral server. Defaults to 30 seconds (configurable).