### PR TITLE
Redirect crash reports to fastly

### DIFF
--- a/src/controllers/crashes.js
+++ b/src/controllers/crashes.js
@@ -1,3 +1,5 @@
+const common = require('../common')
+
 let assert = require('assert')
 let Joi = require('joi')
 let logger = require('logfmt')
@@ -37,19 +39,13 @@ exports.setup = (runtime) => {
     method: 'POST',
     path: '/1/bc-crashes',
     config: {
-      handler: function (request, reply) {
-        let crash_id = randomstring.generate({
-          length: 16,
-          charset: 'hex'
-        })
-        reply(crash_id)
-        const payload = request.payload
-        payload.ts = (new Date()).getTime()
-        payload.crash_id = crash_id
-        delete payload.guid
-        runtime.mongo.models.insertCrash(payload, 'braveCore', (err, results) => {
-          console.log(`crash recorded for version ${payload.ver}`)
-        })
+      description: "Proxy crash reports to Fastly endpoint",
+      handler: {
+        proxy: {
+          uri: process.env.CRASH_PROXY,
+          passThrough: true,
+          timeout: 30000
+        }
       }
     }
   }


### PR DESCRIPTION
  * Crash reports now handled by a third-party (backtrace)
  * Set 301 manually, since hapi default is 302