### PR TITLE
Add optional query param api_key for bc usage ping

### DIFF
--- a/src/controllers/braveCore.js
+++ b/src/controllers/braveCore.js
@@ -25,7 +25,8 @@ let validator = {
     monthly: Joi.valid(booleanString).required(),
     first: Joi.valid(booleanString).required(),
     woi: Joi.string(),
-    dtoi: Joi.string().optional(),
+    dtoi: Joi.string().optional(),    /* Optional for older browser releases. */
+    api_key: Joi.string().optional(), /* Optional for older browser releases. */
     ref: Joi.string()
   }
 }
@@ -46,10 +47,16 @@ let buildUsage = (request) => {
       ref: request.query.ref || 'none',
       country_code: country_code
     }
+
+    /* Params introduced in newer releases of the browser version >= 1.9.x. */
     const dtoi = request.query.dtoi
+    const api_key = request.query.api_key
     if (!common.shouldExcludeCountryCode(country_code) && dtoi
           && dtoi !== 'null')
       usagePing.dtoi = request.query.dtoi
+    if (api_key)
+      usagePing.api_key = api_key
+
     return usagePing
   } else {
     return null

--- a/src/db.js
+++ b/src/db.js
@@ -21,7 +21,8 @@ const usageSchema = Joi.object().keys({
   version: Joi.string(),
   channel: Joi.string(),
   woi: Joi.string(),
-  dtoi: Joi.string().optional(),
+  dtoi: Joi.string().optional(),    /* Optional for older browser releases. */
+  api_key: Joi.string().optional(), /* Optional for older browser releases. */
   ref: Joi.string(),
   country_code: Joi.string(),
   braveDataCenter: Joi.boolean(),


### PR DESCRIPTION
This will be introduced in nightly with
https://github.com/brave/brave-core/pull/5721